### PR TITLE
feat(compare): add category validation for product comparison

### DIFF
--- a/app/controllers/client/SanPhamController.php
+++ b/app/controllers/client/SanPhamController.php
@@ -265,10 +265,22 @@ class SanPhamController
         $sanPhamSoSanh = [];
         $thongSoTheoSanPham = [];
         $tenThongSoMap = [];
+        $compareValidationMessage = '';
+        $danhMucSoSanhId = null;
 
         foreach ($selectedSlugs as $slug) {
             $sanPham = $this->sanPhamModel->layChiTietTheoSlug($slug);
             if (!$sanPham) {
+                continue;
+            }
+
+            $danhMucId = isset($sanPham['danh_muc_id']) ? (int)$sanPham['danh_muc_id'] : 0;
+            if ($danhMucSoSanhId === null && $danhMucId > 0) {
+                $danhMucSoSanhId = $danhMucId;
+            }
+
+            if ($danhMucSoSanhId !== null && $danhMucId > 0 && $danhMucId !== $danhMucSoSanhId) {
+                $compareValidationMessage = 'Chỉ có thể so sánh các sản phẩm cùng danh mục. Một số sản phẩm khác danh mục đã bị bỏ qua.';
                 continue;
             }
 
@@ -401,11 +413,25 @@ class SanPhamController
 
         $products = [];
         $specNameMap = [];
+        $danhMucSoSanhId = null;
 
         foreach ($slugs as $slug) {
             $sanPham = $this->sanPhamModel->layChiTietTheoSlug($slug);
             if (!$sanPham) {
                 continue;
+            }
+
+            $danhMucId = isset($sanPham['danh_muc_id']) ? (int)$sanPham['danh_muc_id'] : 0;
+            if ($danhMucSoSanhId === null && $danhMucId > 0) {
+                $danhMucSoSanhId = $danhMucId;
+            }
+
+            if ($danhMucSoSanhId !== null && $danhMucId > 0 && $danhMucId !== $danhMucSoSanhId) {
+                echo json_encode([
+                    'success' => false,
+                    'message' => 'Chỉ có thể so sánh các sản phẩm cùng danh mục.'
+                ]);
+                exit;
             }
 
             $phienBanList = $this->phienBanModel->layPhienBanTheoSanPham((int)$sanPham['id']);
@@ -444,6 +470,7 @@ class SanPhamController
                 'id' => (int)$sanPham['id'],
                 'slug' => (string)$sanPham['slug'],
                 'ten_san_pham' => (string)$sanPham['ten_san_pham'],
+                'danh_muc_id' => $danhMucId,
                 'hang_san_xuat' => (string)($sanPham['hang_san_xuat'] ?? '-'),
                 'ten_danh_muc' => (string)($sanPham['ten_danh_muc'] ?? '-'),
                 'gia_hien_thi' => $gia,

--- a/app/views/client/san_pham/compare.php
+++ b/app/views/client/san_pham/compare.php
@@ -10,6 +10,15 @@ for ($i = 0; $i < 4; $i++) {
 }
 
 $selectedSlugSet = array_values(array_filter($selectedSlugsForForm, static fn($slug) => $slug !== ''));
+$danhMucKhoaForPicker = null;
+
+foreach (($sanPhamSoSanh ?? []) as $spDangSoSanh) {
+    $dmId = isset($spDangSoSanh['danh_muc_id']) ? (int)$spDangSoSanh['danh_muc_id'] : 0;
+    if ($dmId > 0) {
+        $danhMucKhoaForPicker = $dmId;
+        break;
+    }
+}
 
 $danhMucDangSoSanh = [];
 $hangDangSoSanh = [];
@@ -130,6 +139,12 @@ if (empty($sanPhamTuongTuGoiY)) {
         </div>
     </div>
 
+    <?php if (!empty($compareValidationMessage ?? '')): ?>
+        <div class="alert alert-warning border-0 shadow-sm">
+            <?= htmlspecialchars((string)$compareValidationMessage) ?>
+        </div>
+    <?php endif; ?>
+
     <div class="card compare-picker-card border-0 shadow-sm mb-4">
         <div class="card-body">
             <form method="GET" action="/so-sanh" class="row g-3 align-items-end">
@@ -140,6 +155,12 @@ if (empty($sanPhamTuongTuGoiY)) {
                             <select class="form-select form-select-sm" name="slug[]">
                                 <option value="">-- Chọn sản phẩm --</option>
                                 <?php foreach ($danhSachSanPham as $sp): ?>
+                                    <?php
+                                    $dmIdOption = isset($sp['danh_muc_id']) ? (int)$sp['danh_muc_id'] : 0;
+                                    if ($danhMucKhoaForPicker !== null && $dmIdOption > 0 && $dmIdOption !== $danhMucKhoaForPicker) {
+                                        continue;
+                                    }
+                                    ?>
                                     <option value="<?= htmlspecialchars($sp['slug']) ?>"
                                         <?= $selectedSlugsForForm[$i] === $sp['slug'] ? 'selected' : '' ?>>
                                         <?= htmlspecialchars($sp['ten_san_pham']) ?>
@@ -235,7 +256,7 @@ if (empty($sanPhamTuongTuGoiY)) {
                             <?php foreach ($sanPhamSoSanh as $sp): ?>
                                 <td><?= htmlspecialchars($sp['phien_ban_mac_dinh']['mau_sac'] ?? '-') ?></td>
                             <?php endforeach; ?>
-                        </tr>                   
+                        </tr>
                         <tr>
                             <th class="bg-light">Tổng tồn kho</th>
                             <?php foreach ($sanPhamSoSanh as $sp): ?>

--- a/app/views/client/san_pham/list.php
+++ b/app/views/client/san_pham/list.php
@@ -94,6 +94,11 @@ $mucGiaPreset = [
         color: #fff;
     }
 
+    .btn-compare-toggle.is-locked {
+        opacity: 0.7;
+        cursor: not-allowed;
+    }
+
     .compare-floating-bar {
         position: fixed;
         bottom: 16px;
@@ -504,6 +509,7 @@ $mucGiaPreset = [
                                         type="button"
                                         class="btn btn-outline-danger btn-sm w-100 btn-compare-toggle"
                                         data-slug="<?= htmlspecialchars($sp['slug']) ?>"
+                                        data-category-id="<?= (int)($sp['danh_muc_id'] ?? 0) ?>"
                                         data-name="<?= htmlspecialchars($sp['ten_san_pham']) ?>">
                                         <i class="fa fa-plus me-1"></i>Chọn so sánh
                                     </button>
@@ -561,16 +567,28 @@ $mucGiaPreset = [
 
 <script>
     const COMPARE_STORAGE_KEY = 'fptshop_compare_slugs';
+    const COMPARE_CATEGORY_STORAGE_KEY = 'fptshop_compare_category_id';
     const selectedCompareSlugs = new Set();
+    let selectedCompareCategoryId = null;
     const compareButtons = Array.from(document.querySelectorAll('.btn-compare-toggle'));
     const compareFloatingBar = document.getElementById('compare-floating-bar');
     const compareCount = document.getElementById('compare-count');
     const compareClearBtn = document.getElementById('compare-clear-btn');
     const compareSubmitBtn = document.getElementById('compare-submit-btn');
 
+    function parseCategoryId(rawValue) {
+        const parsed = Number(rawValue);
+        return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+    }
+
     function saveCompareState() {
         try {
             localStorage.setItem(COMPARE_STORAGE_KEY, JSON.stringify(Array.from(selectedCompareSlugs)));
+            if (selectedCompareCategoryId === null) {
+                localStorage.removeItem(COMPARE_CATEGORY_STORAGE_KEY);
+            } else {
+                localStorage.setItem(COMPARE_CATEGORY_STORAGE_KEY, String(selectedCompareCategoryId));
+            }
         } catch (e) {
 
         }
@@ -587,6 +605,12 @@ $mucGiaPreset = [
                     selectedCompareSlugs.add(slug);
                 }
             });
+
+            selectedCompareCategoryId = parseCategoryId(localStorage.getItem(COMPARE_CATEGORY_STORAGE_KEY));
+            if (selectedCompareCategoryId === null && selectedCompareSlugs.size > 0) {
+                const firstMatchedBtn = compareButtons.find((btn) => selectedCompareSlugs.has(btn.dataset.slug));
+                selectedCompareCategoryId = parseCategoryId(firstMatchedBtn?.dataset.categoryId ?? null);
+            }
         } catch (e) {
 
         }
@@ -599,10 +623,26 @@ $mucGiaPreset = [
         compareButtons.forEach((btn) => {
             const slug = btn.dataset.slug;
             const isSelected = selectedCompareSlugs.has(slug);
+            const buttonCategoryId = parseCategoryId(btn.dataset.categoryId ?? null);
+            const isLockedByCategory =
+                selectedCompareCategoryId !== null &&
+                buttonCategoryId !== null &&
+                buttonCategoryId !== selectedCompareCategoryId &&
+                !isSelected;
+
             btn.classList.toggle('active', isSelected);
+            btn.classList.toggle('is-locked', isLockedByCategory);
             btn.innerHTML = isSelected ?
                 '<i class="fa fa-check me-1"></i>Đã chọn so sánh' :
                 '<i class="fa fa-plus me-1"></i>Chọn so sánh';
+
+            if (isLockedByCategory) {
+                btn.title = 'Chỉ so sánh những sản phẩm cùng danh mục';
+                btn.setAttribute('aria-disabled', 'true');
+            } else {
+                btn.removeAttribute('title');
+                btn.removeAttribute('aria-disabled');
+            }
         });
 
         if (count > 0) {
@@ -622,10 +662,23 @@ $mucGiaPreset = [
             const slug = btn.dataset.slug;
             if (!slug) return;
 
+            const buttonCategoryId = parseCategoryId(btn.dataset.categoryId ?? null);
+
             if (selectedCompareSlugs.has(slug)) {
                 selectedCompareSlugs.delete(slug);
+                if (selectedCompareSlugs.size === 0) {
+                    selectedCompareCategoryId = null;
+                }
             } else {
+                if (selectedCompareCategoryId !== null && buttonCategoryId !== null && buttonCategoryId !== selectedCompareCategoryId) {
+                    alert('Bạn chỉ có thể chọn sản phẩm cùng danh mục để so sánh.');
+                    return;
+                }
+
                 selectedCompareSlugs.add(slug);
+                if (selectedCompareCategoryId === null && buttonCategoryId !== null) {
+                    selectedCompareCategoryId = buttonCategoryId;
+                }
             }
 
             renderCompareState();
@@ -634,6 +687,7 @@ $mucGiaPreset = [
 
     compareClearBtn?.addEventListener('click', () => {
         selectedCompareSlugs.clear();
+        selectedCompareCategoryId = null;
         renderCompareState();
     });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Category-restricted product comparisons: Only products from the same category can now be compared together.
  * Compare buttons visually lock when a category is selected, preventing cross-category comparisons.
  * Warning alerts appear when attempting to add products from different categories.
  * Product picker automatically filters to display only products matching the selected comparison category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->